### PR TITLE
NXP-29529: Allow to update nuxeo Helm chart dependencies (elastic)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -88,6 +88,7 @@ jenkins:
         Containers:
           JX-base:
             LimitCpu: "1"
+            LimitMemory: "1Gi"
       Nuxeo-Package-10:
         Name: nuxeo-package-10
         Label: jenkins-nuxeo-package-10


### PR DESCRIPTION
When adding the elastic Helm chart repository, https://helm.elastic.co/, running `helm dependency update nuxeo` fails with `Killed` and exit code 137.
This is most certainly due to an OOM error, maybe because the elastic Helm chart repository has a lot of content.
Increasing the pod memory limit fixes the issue.